### PR TITLE
Initial config support & argument parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # Objects
-obj
+*.o
 
 # Executable
 cnc
 
+compile_commands.json
 # Emacs-specific
 # -*- mode: gitignore; -*-
 *~
@@ -15,6 +16,7 @@ auto-save-list
 tramp
 .\#*
 
+.cache/
 # Org-mode
 .org-id-locations
 *_archive

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,19 @@
-CC = gcc
-CFLAGS = -Wall -g
-TARGET = cnc
+CC?=gcc
+DEBUG ?= 0
+CFLAGS=-Iinclude -Wall -g -DDEBUG=$(DEBUG)
+LDFLAGS=-lcyaml
+DEPS=$(wildcard include/*.h)
+SRC=$(wildcard src/*.c)
+OBJ=$(SRC:src/%.c=%.o)
 
-SRC_DIR = src
-SOURCES = $(wildcard $(SRC_DIR)/*.c)
+%.o: src/%.c $(DEPS)
+	$(CC) -c -o $@ $< $(CFLAGS) $(LDFLAGS)
 
-OBJ_DIR = obj
-OBJECTS = $(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SOURCES))
+cnc: $(OBJ)
+	$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS)
 
-all: $(TARGET)
-
-# Rule for creating object files directory
-$(OBJ_DIR):
-	mkdir -p $(OBJ_DIR)
-
-# Rule for building the target executable
-$(TARGET): $(OBJECTS)
-	$(CC) $(CFLAGS) -o $(TARGET) $(OBJECTS)
-
-# Generic rule for compiling any .c file into an .o file in the obj/ directory
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
-	$(CC) $(CFLAGS) -c $< -o $@
-
-# Clean target for removing compiled files
 clean:
-	rm -f $(TARGET)
-	rm -rf $(OBJ_DIR)
+	rm -f *.o cnc
 
-# Phony targets
-.PHONY: all clean
+valgrind: cnc
+	valgrind --leak-check=full ./cnc -f test.yaml

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,21 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <stdbool.h>
+
+typedef struct postgres_t {
+	const char *host;
+	const char *user;
+	const char *password;
+	const char *port;
+	const char *database;
+} postgres_t;
+
+typedef struct config_t {
+	postgres_t *postgres_config;
+} config_t;
+
+int initialize_config(const char *config_file);
+void free_config(void);
+
+#endif

--- a/src/config.c
+++ b/src/config.c
@@ -1,0 +1,73 @@
+#include "config.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <cyaml/cyaml.h>
+
+static const cyaml_schema_field_t postgres_fields_schema[] = {
+	CYAML_FIELD_STRING_PTR("host", CYAML_FLAG_POINTER, postgres_t, host, 0,
+			       CYAML_UNLIMITED),
+	CYAML_FIELD_STRING_PTR("user", CYAML_FLAG_POINTER, postgres_t, user, 0,
+			       CYAML_UNLIMITED),
+	CYAML_FIELD_STRING_PTR("password", CYAML_FLAG_POINTER, postgres_t,
+			       password, 0, CYAML_UNLIMITED),
+	CYAML_FIELD_STRING_PTR("port", CYAML_FLAG_POINTER, postgres_t, port, 0,
+			       CYAML_UNLIMITED),
+	CYAML_FIELD_STRING_PTR("database", CYAML_FLAG_POINTER, postgres_t,
+			       database, 0, CYAML_UNLIMITED),
+};
+
+static const cyaml_schema_field_t config_fields_schema[] = {
+	CYAML_FIELD_MAPPING_PTR("postgres", CYAML_FLAG_POINTER, config_t,
+				postgres_config, postgres_fields_schema),
+};
+
+static const cyaml_schema_value_t config_schema = {
+	CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER, config_t, config_fields_schema),
+};
+
+static const cyaml_config_t config = {
+	.log_fn = cyaml_log, /* Use the default logging function. */
+	.mem_fn = cyaml_mem, /* Use the default memory allocator. */
+	.log_level = CYAML_LOG_WARNING, /* Logging errors and warnings only. */
+};
+
+config_t *yaml_config;
+
+/* 
+ * initialize_config
+ *
+ *   0 Success
+ *  -1 Error reading file
+ *  -2 Error parsing file
+ *
+ */
+int initialize_config(const char *config_file)
+{
+	int ret = 0;
+	enum cyaml_err err;
+	err = cyaml_load_file(config_file, &config, &config_schema,
+			      (void **)&yaml_config, NULL);
+	if (err != CYAML_OK) {
+		if (err == CYAML_ERR_FILE_OPEN)
+			ret = -1;
+		fprintf(stderr, "ERROR: %s\n", cyaml_strerror(err));
+		ret = -2;
+
+		return ret;
+	}
+
+	return ret;
+}
+
+void free_config(void)
+{
+	free((void *)yaml_config->postgres_config->host);
+	free((void *)yaml_config->postgres_config->user);
+	free((void *)yaml_config->postgres_config->password);
+	free((void *)yaml_config->postgres_config->port);
+	free((void *)yaml_config->postgres_config->database);
+	free(yaml_config->postgres_config);
+	free(yaml_config);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,46 @@
 #include <stdio.h>
+#include <getopt.h>
+#include <string.h>
+#include <stdlib.h>
 
-int main()
+#include "config.h"
+
+extern config_t *yaml_config;
+
+static struct option options[] = {
+	{ "config-file", required_argument, 0, 'f' },
+};
+
+int main(int argc, char **argv)
 {
-	printf("Hello, World!\n");
-	return 0;
+	int ret = 0;
+	int c;
+	char *config_file = NULL;
+
+	while ((c = getopt_long(argc, argv, "f:", options, NULL)) != -1) {
+		switch (c) {
+		case 'f':
+			config_file = strdup(optarg);
+			printf("%s\n", config_file);
+			break;
+		}
+	}
+
+	if (config_file != NULL) {
+		ret = initialize_config(config_file);
+		if (ret != 0) {
+			free((void *)config_file);
+			return ret;
+		}
+
+#if DEBUG == 1
+		printf("%s\t%s\t%s\n", yaml_config->postgres_config->host,
+		       yaml_config->postgres_config->user,
+		       yaml_config->postgres_config->database);
+#endif
+		free((void *)config_file);
+		free_config();
+	}
+
+	return ret;
 }

--- a/test.yaml
+++ b/test.yaml
@@ -1,0 +1,7 @@
+postgres:
+  host: "localhost"
+  user: "postgres"
+  password: "password"
+  port: "5432"
+  database: "postgres"
+


### PR DESCRIPTION
Config fields added:
       Postgres
	 host     : string
	 user     : string
	 password : string
	 port     : string
	 database : string

Arguments added:
       "-f" | "--config-file": Config file to use

We also revisited our Makefile in this commit to avoid the following issues:
   * object files not being found, undefined functions were being called due to linking errors
   * Added DEBUG conditional flag for debug printing
   * Made CC a user-specified variable (if not specified, use gcc)
   * Add -lcyaml
   * Added valgrind

It is also safe to say that you need to install `libcyaml` for this patch to work on your computer.