### PR TITLE
ci: add clang-format test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,19 @@ name: Build CI
 on:
   pull_request:
   push:
+
 jobs:
-  runner-job:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run clang-format style check for C/C++ programs.
+        uses: jidicula/clang-format-action@v4.9.0
+        with:
+          clang-format-version: '14'
+          check-path: '.'
+
+  build-and-valgrind:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -35,4 +46,3 @@ jobs:
             echo "Memory leaks detected"
             exit 1
           fi
-

--- a/include/db/postgres.h
+++ b/include/db/postgres.h
@@ -21,6 +21,6 @@ int connect_pg(struct db_t *);
 void close_pg(struct db_t *pg_db_t);
 int replicate(struct db_t *pg_db_t, struct options *pg_options);
 
-int execve_binary(char* ,char *const[], char *const[]);
+int execve_binary(char *, char *const[], char *const[]);
 
 #endif

--- a/include/email.h
+++ b/include/email.h
@@ -8,7 +8,6 @@ struct upload_status {
 	int lines_read; // Number of lines read in the email body.
 };
 
-
 int send_email(const char *to, const char *subject, const char *body);
 
 #endif


### PR DESCRIPTION
Also
 * Fixed some clang-format errors:
    * include/email.h
    * include/db/postgres.h
* Changed job name from "runner-job" -> "build-and-valgrind"

Closes #22 