### PR TITLE
main: add help flag and message

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -14,15 +14,31 @@ extern bool verbose;
 static struct option options[] = {
 	{ "config-file", required_argument, NULL, 'f' },
 	{ "verbose", no_argument, NULL, 'v' },
+	{ "help", no_argument, NULL, 'h' },
+	{ 0, 0, 0, 0 } // End of options
 };
+
+void help(void)
+{
+	printf("Usage: cnc [options]\n");
+	printf("Options:\n");
+	printf("  -f, --config-file <file>  Specify the config file to use\n");
+	printf("  -v, --verbose             Run in verbose mode\n");
+	printf("  -h, --help                Print this help message\n");
+}
 
 int main(int argc, char **argv)
 {
+	if (argc == 1) {
+		help();
+		return 0;
+	}
+
 	int ret = 0;
 	int c;
 	char *config_file = NULL;
 
-	while ((c = getopt_long(argc, argv, "f:v", options, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "f:vh", options, NULL)) != -1) {
 		switch (c) {
 		case 'f':
 			config_file = strdup(optarg);
@@ -31,6 +47,10 @@ int main(int argc, char **argv)
 		case 'v':
 			verbose = true;
 			break;
+		case 'h':
+		default:
+			help();
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
Usage:

- `cnc -h`
- `cnc --help`

Help message is also triggered by not providing any arguments.