### PR TITLE
Add Docker support and documentation for CNC application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:latest as builder
+
+# Install build dependencies
+RUN apk add --no-cache gcc musl-dev make \
+    curl-dev postgresql-dev inih-dev
+
+WORKDIR /app
+COPY . .
+
+RUN make
+
+FROM alpine:latest
+
+# Install runtime libraries
+RUN apk add --no-cache \
+    libpq curl inih
+
+COPY --from=builder /app/cnc /cnc
+
+# Set the binary as the entrypoint of the container
+ENTRYPOINT ["/cnc"]

--- a/docs/docker.adoc
+++ b/docs/docker.adoc
@@ -1,0 +1,30 @@
+= Docker Usage Documentation
+
+This document provides instructions on how to build and run the CNC application using Docker.
+
+== Building the Docker Image
+
+First, build the Docker image using the provided Dockerfile. The Dockerfile creates a lightweight, Alpine-based image for running the CNC application. It compiles the application in a builder stage and then creates a final image containing only the compiled binary and its runtime dependencies.
+
+[source,sh]
+----
+docker build -t cnc .
+----
+
+== Running the CNC Application in a Docker Container
+
+To run the CNC application inside a Docker container, use the `docker run` command. You need to mount the configuration file (`test.ini`) from the host into the container to ensure the application can access it.
+
+[source,sh]
+----
+docker run \
+        -v /path/to/your/configs/test.ini:/path/inside/container/test.ini \
+        cnc -f /path/inside/container/test.ini
+----
+
+In the command above:
+
+* The `-v` option mounts the `test.ini` file from the host system into the container at the location `/configs/test.ini`.
+* `cnc -f /configs/test.ini` runs the CNC application inside the container and instructs it to use the mounted configuration file.
+
+NOTE: Remember to replace `/home/charmitro/Documents/git/cnc/configs/test.ini` with the actual path to your `test.ini` file on your host machine.


### PR DESCRIPTION
This commit introduces Docker support for the CNC application. It includes a Dockerfile for building a lightweight, Alpine-based Docker image for the application. The Dockerfile is set up with a multi-stage build process: the first stage compiles the application using Alpine as the base image and the second stage prepares the final image containing only the necessary runtime dependencies and the compiled binary.

Additionally, a documentation file (docker.adoc) is added. Providing instructions on how to build and run the CNC application inside a Docker container, including how to mount a configuration file from the host into the container.

Changes include:

- `Dockerfile`: Defines the multi-stage build process for creating a minimal Docker image.
- `docs/docker.adoc`: Contains detailed instructions for building the Docker image and running the CNC application inside a Docker container.


Closes #31 