### PR TITLE
rust: enhance email functionality

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,24 @@
+# Basic
+hard_tabs = true
+max_width = 65
+use_small_heuristics = "Max"
+# Imports
+imports_granularity = "Crate"
+reorder_imports = true
+# Consistency
+newline_style = "Unix"
+# Format comments
+comment_width = 80
+wrap_comments = true
+# Misc
+chain_width = 60
+spaces_around_ranges = false
+binop_separator = "Back"
+reorder_impl_items = false
+match_arm_leading_pipes = "Preserve"
+match_arm_blocks = false
+match_block_trailing_comma = true
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true
+edition = "2021"

--- a/include/rust/email-bindings.h
+++ b/include/rust/email-bindings.h
@@ -3,4 +3,66 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-int32_t send_email(const char *body);
+/**
+ * Represents the necessary information to send an email.
+ * Struct is designed to be compatible with C, allowing for easy FFI.
+ */
+typedef struct EmailInfo {
+	const char *from;
+	const char *const *to;
+	uintptr_t to_len;
+	const char *cc;
+	const char *body;
+	const char *smtp_host;
+	const char *smtp_username;
+	const char *smtp_password;
+} EmailInfo;
+
+/**
+ * Sends an email based on the provided `EmailInfo`.
+ * Initializes logging, constructs the email message, and sends it using SMTP.
+ *
+ * # Arguments
+ *
+ * * `email_info` - Struct containing information about the email to be sent.
+ *
+ * # Returns
+ *
+ * Returns `0` on success, `-1` on failure.
+ * # Example Usage in C
+ *
+ * This example demonstrates how to construct and pass an `EmailInfo` struct from C,
+ * calling the `send_email` function exposed by Rust.
+ *
+ * ```c
+ * #include <stdio.h>
+ * #include "path/to/generated_header.h" // Include the generated header for Rust FFI
+ *
+ * int main() {
+ *     // Email information
+ *     const char* from = "sender@example.com";
+ *     const char* to[] = {"recipient1@example.com", "recipient2@example.com"};
+ *     size_t to_len = 2; // Number of recipients
+ *     const char* cc = "cc@example.com";
+ *     const char* body = "Hello from C! This is the email body.";
+ *	const char *smtp_host = "posteo.de";
+ *	const char *smtp_username = "username";
+ *	const char *smtp_password = "password";
+ *
+ *	// Construct the EmailInfo struct as defined in Rust, adapted for use in C
+ *	EmailInfo email_info = {
+ *		.from = from,
+ *		.to = to,
+ *		.to_len = to_len,
+ *		.cc = cc,
+ *		.body = body,
+ *		.smtp_host = smtp_host,
+ *		.smtp_username = smtp_username,
+ *		.smtp_password = smtp_password,
+ *	};
+ *
+ *     // Call the `send_email` function and capture the return value
+ *     int result = send_email(email_info);
+ * ```
+ */
+int32_t send_email(struct EmailInfo email_info);

--- a/rust/email/build.rs
+++ b/rust/email/build.rs
@@ -1,16 +1,15 @@
 extern crate cbindgen;
 
-use std::env;
 use cbindgen::Language;
+use std::env;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+	let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    cbindgen::Builder::new()
-      .with_crate(crate_dir)
-      .with_language(Language::C)
-      .generate()
-      .expect("Unable to generate bindings")
-      .write_to_file("../../include/rust/email-bindings.h");
+	cbindgen::Builder::new()
+		.with_crate(crate_dir)
+		.with_language(Language::C)
+		.generate()
+		.expect("Unable to generate bindings")
+		.write_to_file("../../include/rust/email-bindings.h");
 }
-

--- a/rust/email/src/lib.rs
+++ b/rust/email/src/lib.rs
@@ -1,58 +1,142 @@
 use lettre::{
-    message::header::ContentType, transport::smtp::authentication::Credentials, Message,
-    SmtpTransport, Transport,
+	message::header::ContentType,
+	transport::smtp::authentication::Credentials, Message,
+	SmtpTransport, Transport,
 };
-use std::ffi::CStr;
-use std::os::raw::c_char;
+use std::{ffi::CStr, os::raw::c_char, slice};
 
+/// Represents the necessary information to send an email.
+/// Struct is designed to be compatible with C, allowing for easy FFI.
+#[repr(C)]
+pub struct EmailInfo {
+	from: *const c_char,
+	to: *const *const c_char,
+	to_len: usize,
+	cc: *const c_char,
+	body: *const c_char,
+
+	smtp_host: *const c_char,
+	smtp_username: *const c_char,
+	smtp_password: *const c_char,
+}
+
+/// Converts a C-style string to a Rust `String`.
+/// Returns `Ok(String)` if conversion is successful, `Err(i32)` if the input string is null.
+///
+/// # Arguments
+///
+/// * `str_` - A pointer to the null-terminated C-style string to convert.
+fn c_char_to_string(str_: *const c_char) -> Result<String, i32> {
+	unsafe {
+		if str_.is_null() {
+			return Err(-1);
+		}
+		Ok(CStr::from_ptr(str_).to_string_lossy().into_owned())
+	}
+}
+
+/// Sends an email based on the provided `EmailInfo`.
+/// Initializes logging, constructs the email message, and sends it using SMTP.
+///
+/// # Arguments
+///
+/// * `email_info` - Struct containing information about the email to be sent.
+///
+/// # Returns
+///
+/// Returns `0` on success, `-1` on failure.
+/// # Example Usage in C
+///
+/// This example demonstrates how to construct and pass an `EmailInfo` struct from C,
+/// calling the `send_email` function exposed by Rust.
+///
+/// ```c
+/// #include <stdio.h>
+/// #include "path/to/generated_header.h" // Include the generated header for Rust FFI
+///
+/// int main() {
+///     // Email information
+///     const char* from = "sender@example.com";
+///     const char* to[] = {"recipient1@example.com", "recipient2@example.com"};
+///     size_t to_len = 2; // Number of recipients
+///     const char* cc = "cc@example.com";
+///     const char* body = "Hello from C! This is the email body.";
+///	const char *smtp_host = "posteo.de";
+///	const char *smtp_username = "username";
+///	const char *smtp_password = "password";
+///
+///	// Construct the EmailInfo struct as defined in Rust, adapted for use in C
+///	EmailInfo email_info = {
+///		.from = from,
+///		.to = to,
+///		.to_len = to_len,
+///		.cc = cc,
+///		.body = body,
+///		.smtp_host = smtp_host,
+///		.smtp_username = smtp_username,
+///		.smtp_password = smtp_password,
+///	};
+///
+///     // Call the `send_email` function and capture the return value
+///     int result = send_email(email_info);
+/// ```
 #[no_mangle]
-pub extern "C" fn send_email(body: *const c_char) -> i32 {
-    tracing_subscriber::fmt::init();
+pub extern "C" fn send_email(email_info: EmailInfo) -> i32 {
+	tracing_subscriber::fmt::init();
 
-    let c_str = unsafe {
-        if body.is_null() {
-            return -1; // Return an error code if the input is null
-        }
-        CStr::from_ptr(body)
-    };
+	let from_str = c_char_to_string(email_info.from).unwrap();
+	let cc_str = c_char_to_string(email_info.cc).unwrap();
+	let body_str = c_char_to_string(email_info.body).unwrap();
 
-    let body_str = match c_str.to_str() {
-        Ok(s) => s,
-        Err(_) => return -1, // Return an error code if the conversion fails
-    };
+	// Convert the 'to' C string array to a Vec of Rust Strings
+	let to_strs: Vec<String> = unsafe {
+		if email_info.to.is_null() {
+			return -1;
+		}
+		slice::from_raw_parts(email_info.to, email_info.to_len)
+			.iter()
+			.map(|&c_str| {
+				CStr::from_ptr(c_str)
+					.to_string_lossy()
+					.into_owned()
+			})
+			.collect()
+	};
 
-    let email = Message::builder()
-        .from(
-            "Charalampos Mitrodimas <charmitro@posteo.net>"
-                .parse()
-                .unwrap(),
-        )
-        .to("Charalampos Mitrodimas <trsbisb@gmail.com>"
-            .parse()
-            .unwrap())
-        .subject("Calling Rust from C")
-        .header(ContentType::TEXT_PLAIN)
-        .body(String::from(body_str))
-        .unwrap();
+	let mut email_builder = Message::builder()
+		.from(from_str.parse().unwrap())
+		.subject("Calling Rust from C")
+		.header(ContentType::TEXT_PLAIN);
 
-    let creds = Credentials::new("username".to_owned(), "password".to_owned());
+	for addr in to_strs.iter() {
+		email_builder = email_builder.to(addr.parse().unwrap());
+	}
 
-    // Open a remote connection to gmail
+	let email = email_builder
+		.cc(cc_str.parse().unwrap())
+		.body(body_str)
+		.unwrap();
 
-    let mailer = SmtpTransport::starttls_relay("posteo.de")
-        .unwrap()
-        .credentials(creds)
-        .build();
+	let creds = Credentials::new(
+		c_char_to_string(email_info.smtp_username).unwrap(),
+		c_char_to_string(email_info.smtp_password).unwrap(),
+	);
 
-    // Send the email
-    match mailer.send(&email) {
-        Ok(_) => {
-            println!("Email success.");
-            return 0;
-        }
-        Err(_) => {
-            println!("Email failure.");
-            return -1;
-        }
-    }
+	let host_str =
+		c_char_to_string(email_info.smtp_host).unwrap();
+	let mailer = SmtpTransport::starttls_relay(&host_str)
+		.unwrap()
+		.credentials(creds)
+		.build();
+
+	match mailer.send(&email) {
+		Ok(_) => {
+			println!("Email success.");
+			0
+		},
+		Err(_) => {
+			println!("Email failure.");
+			-1
+		},
+	}
 }


### PR DESCRIPTION
This update significantly enhances the interface for sending emails from C to Rust by introducing a structured approach with the `EmailInfo` struct. The `EmailInfo` struct formalizes the parameters for sending an email, including sender, recipients, CC, and body, making it easier for C developers to utilize the Rust email sending functionality.

Key changes include:

  - Introduction of the `EmailInfo` struct in C bindings, providing a clear and structured way to pass email information from C to Rust.
  - Detailed documentation comments added to `email-bindings.h` to guide C developers on using the `EmailInfo` struct and the `send_email` function, with example usage that demonstrates constructing the `EmailInfo` struct and invoking the email sending process.
  - Refinement of the Rust `send_email` function to accept an `EmailInfo` struct as its parameter, streamlining the process of email construction and sending within the Rust code.