### PR TITLE
rust: email: do not panic if `cc` is null

### DIFF
--- a/include/rust/email-bindings.h
+++ b/include/rust/email-bindings.h
@@ -45,21 +45,21 @@ typedef struct EmailInfo {
  *     size_t to_len = 2; // Number of recipients
  *     const char* cc = "cc@example.com";
  *     const char* body = "Hello from C! This is the email body.";
- *	const char *smtp_host = "posteo.de";
- *	const char *smtp_username = "username";
- *	const char *smtp_password = "password";
+ *     const char *smtp_host = "posteo.de";
+ *     const char *smtp_username = "username";
+ *     const char *smtp_password = "password";
  *
- *	// Construct the EmailInfo struct as defined in Rust, adapted for use in C
- *	EmailInfo email_info = {
- *		.from = from,
- *		.to = to,
- *		.to_len = to_len,
- *		.cc = cc,
- *		.body = body,
- *		.smtp_host = smtp_host,
- *		.smtp_username = smtp_username,
- *		.smtp_password = smtp_password,
- *	};
+ *     // Construct the EmailInfo struct as defined in Rust, adapted for use in C
+ *     EmailInfo email_info = {
+ *             .from = from,
+ *             .to = to,
+ *             .to_len = to_len,
+ *             .cc = cc,
+ *             .body = body,
+ *             .smtp_host = smtp_host,
+ *             .smtp_username = smtp_username,
+ *             .smtp_password = smtp_password,
+ *     };
  *
  *     // Call the `send_email` function and capture the return value
  *     int result = send_email(email_info);

--- a/rust/email/src/lib.rs
+++ b/rust/email/src/lib.rs
@@ -61,21 +61,21 @@ fn c_char_to_string(str_: *const c_char) -> Result<String, i32> {
 ///     size_t to_len = 2; // Number of recipients
 ///     const char* cc = "cc@example.com";
 ///     const char* body = "Hello from C! This is the email body.";
-///	const char *smtp_host = "posteo.de";
-///	const char *smtp_username = "username";
-///	const char *smtp_password = "password";
+///     const char *smtp_host = "posteo.de";
+///     const char *smtp_username = "username";
+///     const char *smtp_password = "password";
 ///
-///	// Construct the EmailInfo struct as defined in Rust, adapted for use in C
-///	EmailInfo email_info = {
-///		.from = from,
-///		.to = to,
-///		.to_len = to_len,
-///		.cc = cc,
-///		.body = body,
-///		.smtp_host = smtp_host,
-///		.smtp_username = smtp_username,
-///		.smtp_password = smtp_password,
-///	};
+///     // Construct the EmailInfo struct as defined in Rust, adapted for use in C
+///     EmailInfo email_info = {
+///             .from = from,
+///             .to = to,
+///             .to_len = to_len,
+///             .cc = cc,
+///             .body = body,
+///             .smtp_host = smtp_host,
+///             .smtp_username = smtp_username,
+///             .smtp_password = smtp_password,
+///     };
 ///
 ///     // Call the `send_email` function and capture the return value
 ///     int result = send_email(email_info);
@@ -110,6 +110,14 @@ pub extern "C" fn send_email(email_info: EmailInfo) -> i32 {
 
 	for addr in to_strs.iter() {
 		email_builder = email_builder.to(addr.parse().unwrap());
+	}
+
+	match c_char_to_string(email_info.cc) {
+		Ok(str_) => {
+			email_builder =
+				email_builder.cc(str_.parse().unwrap());
+		},
+		Err(_) => println!("No `cc` recipient provided."),
 	}
 
 	let email = email_builder


### PR DESCRIPTION
Also changed tabs to spaces in doc comments, as clippy suggested.