### PR TITLE
email: allow multiple `to` and `cc` in SMTP config

### DIFF
--- a/configs/test.ini
+++ b/configs/test.ini
@@ -21,3 +21,8 @@ password = 123
 smtp_host = posteo.de
 smtp_port = 587
 auth_mode = tls
+
+from = charmitro@posteo.net
+to = charmitro@pm.me, trsbisb@gmail.com
+cc = charmitro@gmail.com, charmitro@terrasync.net
+

--- a/include/config.h
+++ b/include/config.h
@@ -41,8 +41,10 @@ typedef struct smtp_t {
 	auth_mode_t auth_mode;
 
 	const char *from;
-	const char *to;
-	const char *cc;
+	char *to[10];
+	int to_len;
+	char *cc[10];
+	int cc_len;
 } smtp_t;
 
 typedef struct config_t {
@@ -54,5 +56,9 @@ int initialize_config(const char *config_file);
 void free_config(void);
 int handler(void *user, const char *section, const char *name,
 	    const char *value);
+
+/* Utilities */
+void config_split_array_string(char *dest_array[], const char *value, int *len);
+void remove_spaces(char *s);
 
 #endif

--- a/include/rust/email-bindings.h
+++ b/include/rust/email-bindings.h
@@ -11,7 +11,8 @@ typedef struct EmailInfo {
 	const char *from;
 	const char *const *to;
 	uintptr_t to_len;
-	const char *cc;
+	const char *const *cc;
+	uintptr_t cc_len;
 	const char *body;
 	const char *smtp_host;
 	const char *smtp_username;
@@ -43,7 +44,8 @@ typedef struct EmailInfo {
  *     const char* from = "sender@example.com";
  *     const char* to[] = {"recipient1@example.com", "recipient2@example.com"};
  *     size_t to_len = 2; // Number of recipients
- *     const char* cc = "cc@example.com";
+ *     const char* cc[] = {"recipient1@example.com", "recipient2@example.com"};
+ *     size_t cc_len = 2; // Number of recipients
  *     const char* body = "Hello from C! This is the email body.";
  *     const char *smtp_host = "posteo.de";
  *     const char *smtp_username = "username";
@@ -55,6 +57,7 @@ typedef struct EmailInfo {
  *             .to = to,
  *             .to_len = to_len,
  *             .cc = cc,
+ *             .cc_len = cc_len,
  *             .body = body,
  *             .smtp_host = smtp_host,
  *             .smtp_username = smtp_username,

--- a/rust/email/Cargo.lock
+++ b/rust/email/Cargo.lock
@@ -175,7 +175,6 @@ version = "0.1.0"
 dependencies = [
  "cbindgen",
  "lettre",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -469,16 +468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,12 +531,6 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "percent-encoding"
@@ -695,15 +678,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,12 +685,6 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -797,16 +765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
-name = "thread_local"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,41 +803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
-dependencies = [
- "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
-dependencies = [
- "nu-ansi-term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,12 +833,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/rust/email/Cargo.toml
+++ b/rust/email/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib"]      # Creates dynamic lib
 
 [dependencies]
 lettre = "0.11.4"
-tracing-subscriber = "0.3.18"
 
 [build-dependencies]
 cbindgen = "0.24.0"


### PR DESCRIPTION
Changelog:
  - The `test.ini` file has been updated to include examples of multiple
    recipients for both `to` and `cc` fields.
  - Adjusted the `smtp_t` structure in `include/config.h` to accommodate
    arrays for `to` and `cc`, allowing up to 10 recipients initially for
    each field.
  - Introduced utility functions `remove_spaces` and `split_str` in
    `src/config.c` to parse the comma-separated email addresses from the
    configuration file and prepare them for use in the SMTP
    settings.
  - Replacing the previous single-string assignment with a more robust
    handling suitable for multiple recipients.
  - Modifying the `EmailInfo` struct to support an array of strings for
    both `to` and `cc` fields, including the length of these arrays.
  - Updating the example usage documentation within `email-bindings.h`
    to reflect the ability to specify multiple `to` and `cc` recipients.
  - Simplifying the email sending function `send_email` in `lib.rs` by
    updating the handling of CC recipients to iterate over an array of
    strings.