### PR TITLE
rust: read email body from file

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -54,7 +54,7 @@ extern FILE *log_file;
 	fprintf(log_file, ANSI_COLOR_RESET);
 
 bool get_verbose(void);
-void construct_log_filename(char **, const char *);
+void construct_log_filename(char **, char *);
 
 /*
  *  construct_log_filepath()

--- a/include/rust/email-bindings.h
+++ b/include/rust/email-bindings.h
@@ -13,7 +13,7 @@ typedef struct EmailInfo {
 	uintptr_t to_len;
 	const char *const *cc;
 	uintptr_t cc_len;
-	const char *body;
+	const char *filepath;
 	const char *smtp_host;
 	const char *smtp_username;
 	const char *smtp_password;
@@ -58,7 +58,7 @@ typedef struct EmailInfo {
  *             .to_len = to_len,
  *             .cc = cc,
  *             .cc_len = cc_len,
- *             .body = body,
+ *             .filepath = filepath,
  *             .smtp_host = smtp_host,
  *             .smtp_username = smtp_username,
  *             .smtp_password = smtp_password,

--- a/src/log.c
+++ b/src/log.c
@@ -6,13 +6,16 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "util.h"
+#include "config.h"
 
 bool verbose;
 FILE *log_file;
+extern config_t *ini_config;
 
-void construct_log_filename(char **log_filename, const char *log_filepath)
+void construct_log_filename(char **log_filename, char *log_filepath)
 {
 	time_t t = time(NULL);
 	struct tm tm = *localtime(&t);
@@ -20,6 +23,7 @@ void construct_log_filename(char **log_filename, const char *log_filepath)
 	sprintf(*log_filename, "%scnc%02d%02d%02d_%02d%02d%02d.log",
 		log_filepath, tm.tm_mday, tm.tm_mon + 1, tm.tm_year + 1900,
 		tm.tm_hour, tm.tm_min, tm.tm_sec);
+	ini_config->general_config->log_filepath = strdup(*log_filename);
 }
 
 int construct_log_filepath(const char *config_filepath, char **log_filepath)


### PR DESCRIPTION
This commit will make it possible to read the mail body from a file. The `EmailInfo` struct will have a `filepath` parameter instead of `body`.

Changelog:
	- Changed `EmailInfo` parameter from `body` to `filepath`
	- Added a helper function `read_email_body()` to read the context of the file located in `filapath`