### PR TITLE
Resolve macOS build system issue

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,14 @@
 bin_PROGRAMS = cnc
-cnc_SOURCES = src/cnc.c src/config.c src/db.c src/log.c src/main.c src/postgres.c src/util.c
+cnc_SOURCES = src/postgres.c src/cnc.c src/config.c src/db.c src/log.c src/main.c src/util.c
 cnc_LDADD = -linih -lpq $(RUST_LIBS)
 cnc_CFLAGS = -Iinclude -I/usr/include/postgresql/ -Wall -g
 
 # Define Rust libraries and their paths
+if MACOS
+RUST_LIBS = rust/email/target/debug/libemail.dylib
+else
 RUST_LIBS = rust/email/target/debug/libemail.so
+endif
 
 # Use BUILT_SOURCES to ensure rust_libs is considered a prerequisite
 BUILT_SOURCES = $(RUST_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,8 @@ AS_IF([test "x$CARGO" = "xno"], [AC_MSG_ERROR([Cargo is required to build Rust l
 # Detect macOS and adjust CFLAGS and LDFLAGS for Homebrew
 AS_CASE([$host_os],
   [darwin*], [
+    AC_DEFINE([MACOS], [1], [Define on macOS])
+    AM_CONDITIONAL([MACOS], [true])
     # Attempt to determine the Homebrew prefix
     BREW_PREFIX=$(brew --prefix 2>/dev/null || echo "/usr/local")
     if test -d "$BREW_PREFIX/include"; then
@@ -21,6 +23,7 @@ AS_CASE([$host_os],
   ],
   [*], [
     # Default case (for non-darwin platforms) can be left empty or used for other platform-specific settings
+    AM_CONDITIONAL([MACOS], [false])
   ]
 )
 

--- a/src/db.c
+++ b/src/db.c
@@ -4,7 +4,10 @@
 
 #include <stddef.h>
 #include <stdlib.h>
-#include <errno.h>
+#include <sys/errno.h>
+
+init_db_func init_functions[MAX_AVAILABLE_DBS];
+int num_init_functions = 0;
 
 /* We need to hold info of how many
  * available databases implementations
@@ -19,9 +22,10 @@ int execute_db_operations(void)
 	available_dbs = (struct db_operations **)calloc(
 		MAX_AVAILABLE_DBS, sizeof(struct db_operations **));
 
-	section_foreach_entry(my_array, init_db_func_ptr_t, entry)
+	init_db_func init_function;
+	section_foreach_entry(init_function)
 	{
-		int ret = entry->func();
+		int ret = init_function();
 		if (ret == -ENOMEM) {
 			pr_error_fd("Error allocating memory\n");
 			free(available_dbs);

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -1,6 +1,12 @@
 #include <string.h>
 #include <unistd.h>
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <mach/error.h>
+#else
 #include <error.h>
+#endif
+
 #include <sys/stat.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
We had problems building/running on macOS due to the differences between GCC and Clang compilers. Clang could not treat our ADD_FUNC macro suite the way we intented to do.

Apart from that we also had problems including error.h and errno.h.