### PR TITLE
utils: log: config: make some utility functions inline static

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -75,6 +75,15 @@ int handler(void *user, const char *section, const char *name,
 
 /* Utilities */
 void config_split_array_string(char *dest_array[], const char *value, int *len);
-void remove_spaces(char *s);
+
+inline static void remove_spaces(char *s)
+{
+	char *d = s;
+	do {
+		while (*d == ' ') {
+			++d;
+		}
+	} while ((*s++ = *d++));
+}
 
 #endif

--- a/include/log.h
+++ b/include/log.h
@@ -10,7 +10,13 @@
 #define LOG_FILEPATH "/var/log/"
 #define LOG_DIRECTORY "/var/log/cnc/"
 
+extern bool verbose;
 extern FILE *log_file;
+
+static inline bool get_verbose(void)
+{
+	return verbose;
+}
 
 /* Only if `verbose` is enabled (throught "-v" flag)
  * this print is going to print to STDOUT. Name
@@ -53,7 +59,6 @@ extern FILE *log_file;
 	fprintf(log_file, __VA_ARGS__);                                \
 	fprintf(log_file, ANSI_COLOR_RESET);
 
-bool get_verbose(void);
 void construct_log_filename(char **, char *);
 
 /*

--- a/include/util.h
+++ b/include/util.h
@@ -4,6 +4,8 @@
 #include <errno.h>
 #include <stdio.h>
 
+#include "log.h"
+
 /* Write/Read end for pipes */
 #define READ_END 0
 #define WRITE_END 1
@@ -63,6 +65,17 @@ int mkdir_p(char *path);
  * -ENOMEM of failure of `strdup` call
  *
  */
-int cnc_strdup(char **string, char *string_to_dup);
+static inline int cnc_strdup(char **string, char *string_to_dup)
+{
+	char *temp_string = strdup(string_to_dup);
+	if (temp_string != NULL) {
+		*string = temp_string;
+	} else {
+		pr_error("strdup: Failed to allocate memory.\n");
+		return -ENOMEM;
+	}
+
+	return 0;
+}
 
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -13,16 +13,6 @@ extern FILE *log_file;
 #define CHECK_SECTION(s) strcmp(section, s) == 0
 #define MATCH(s, n) strcmp(section, s) == 0 && strcmp(name, n) == 0
 
-void remove_spaces(char *s)
-{
-	char *d = s;
-	do {
-		while (*d == ' ') {
-			++d;
-		}
-	} while ((*s++ = *d++));
-}
-
 void config_split_array_string(char *dest_array[], const char *value, int *len)
 {
 	int idx = 0;

--- a/src/log.c
+++ b/src/log.c
@@ -11,7 +11,8 @@
 #include "util.h"
 #include "config.h"
 
-bool verbose;
+bool verbose = false;
+
 FILE *log_file;
 extern config_t *ini_config;
 
@@ -83,9 +84,4 @@ int construct_log_filepath(const char *config_filepath, char **log_filepath)
 	}
 
 	return 0;
-}
-
-bool get_verbose(void)
-{
-	return verbose;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -165,16 +165,3 @@ int mkdir_p(char *path)
 
 	return 0;
 }
-
-inline int cnc_strdup(char **string, char *string_to_dup)
-{
-	char *temp_string = strdup(string_to_dup);
-	if (temp_string != NULL) {
-		*string = temp_string;
-	} else {
-		pr_error("strdup: Failed to allocate memory.\n");
-		return -ENOMEM;
-	}
-
-	return 0;
-}


### PR DESCRIPTION
This commit inlines several small utility functions, namely `remove_spaces`, `get_verbose`, and `cnc_strdup`, directly within their respective header files to potentially reduce function call overhead and improve performance. By making these functions inline, we hint to the compiler that it should attempt to embed these functions directly at the call site, which can lead to faster execution for these frequently used utilities.