### PR TITLE
cnc: Add --version flag to display version and commit hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
+          sudo apt update
           sudo apt install libinih-dev
           sudo apt install libcurl4-openssl-dev
           sudo apt install valgrind

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = cnc
 cnc_SOURCES = src/postgres.c src/cnc.c src/config.c src/db.c src/log.c src/main.c src/util.c
 cnc_LDADD = -linih -lpq $(RUST_LIBS)
-cnc_CFLAGS = -Iinclude -I/usr/include/postgresql/ -Wall -g
+cnc_CFLAGS = -Iinclude -I/usr/include/postgresql/ -Wall -g -DCOMMIT_HASH=\"@COMMIT_HASH@\"
 
 # Define Rust libraries and their paths
 if MACOS

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
-AC_INIT([cnc], [1.0], [charmitor@posteo.net])
+AC_INIT([cnc], [m4_esyscmd_s([git describe --tags --always | tr -d '\n'])], [charmitor@posteo.net])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+
 AC_PROG_CC
 AC_CANONICAL_HOST
 
@@ -39,12 +40,12 @@ AS_CASE([$host_os],
 # Checks for libraries and headers
 # Check for inih
 AC_CHECK_LIB([inih], [ini_parse], [], [
-    AC_MSG_ERROR([*** The inih library is required but missing. ***])
+  AC_MSG_ERROR([*** The inih library is required but missing. ***])
 ])
 
 # Check for PostgreSQL
 AC_CHECK_LIB([pq], [PQconnectdb], [], [
-    AC_MSG_ERROR([*** libpq is required but missing. ***])
+  AC_MSG_ERROR([*** libpq is required but missing. ***])
 ])
 
 # Checks for header files
@@ -53,8 +54,10 @@ AC_CHECK_HEADERS([postgresql/libpq-fe.h])
 # Adjusting CFLAGS and LDFLAGS
 CFLAGS="$CFLAGS -Iinclude -I/usr/include/postgresql/ -Wall -g"
 LDFLAGS="$LDFLAGS -linih -lpq"
+
+AC_SUBST([COMMIT_HASH], [$(git rev-parse HEAD)])
+
 AC_SUBST([CFLAGS])
 AC_SUBST([LDFLAGS])
-
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/include/rust/email-bindings.h
+++ b/include/rust/email-bindings.h
@@ -5,7 +5,8 @@
 
 /**
  * Represents the necessary information to send an email.
- * Struct is designed to be compatible with C, allowing for easy FFI.
+ * Struct is designed to be compatible with C, allowing for easy
+ * FFI.
  */
 typedef struct EmailInfo {
 	const char *from;
@@ -21,19 +22,22 @@ typedef struct EmailInfo {
 
 /**
  * Sends an email based on the provided `EmailInfo`.
- * Initializes logging, constructs the email message, and sends it using SMTP.
+ * Initializes logging, constructs the email message, and sends
+ * it using SMTP.
  *
  * # Arguments
  *
- * * `email_info` - Struct containing information about the email to be sent.
+ * * `email_info` - Struct containing information about the
+ *   email to be sent.
  *
  * # Returns
  *
  * Returns `0` on success, `-1` on failure.
  * # Example Usage in C
  *
- * This example demonstrates how to construct and pass an `EmailInfo` struct from C,
- * calling the `send_email` function exposed by Rust.
+ * This example demonstrates how to construct and pass an
+ * `EmailInfo` struct from C, calling the `send_email` function
+ * exposed by Rust.
  *
  * ```c
  * #include <stdio.h>

--- a/src/cnc.c
+++ b/src/cnc.c
@@ -18,6 +18,7 @@ static struct option options[] = {
 	{ "config-file", required_argument, NULL, 'f' },
 	{ "verbose", no_argument, NULL, 'v' },
 	{ "help", no_argument, NULL, 'h' },
+	{ "version", no_argument, NULL, 'V' },
 	{ 0, 0, 0, 0 } // End of options
 };
 
@@ -28,6 +29,7 @@ void help(void)
 	pr_info("  -f, --config-file <file>  Specify the config file to use\n");
 	pr_info("  -v, --verbose             Run in verbose mode\n");
 	pr_info("  -h, --help                Print this help message\n");
+	pr_info(" -V, --version Print the version information\n");
 }
 
 int process_args(int argc, char **argv)
@@ -42,7 +44,7 @@ int process_args(int argc, char **argv)
 	char *config_file = NULL;
 
 	optind = 0;
-	while ((c = getopt_long(argc, argv, "f:vh", options, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "f:vhV", options, NULL)) != -1) {
 		switch (c) {
 		case 'f':
 			config_file = strdup(optarg);
@@ -51,8 +53,12 @@ int process_args(int argc, char **argv)
 		case 'v':
 			verbose = true;
 			break;
-		case 'h':
 		case '?':
+		case 'V':
+			pr_info("Version: %s\n", VERSION);
+			pr_info("Commit: %s\n", COMMIT_HASH);
+			return 0;
+		case 'h':
 		default:
 			help();
 			return 0;


### PR DESCRIPTION
This patch introduces a new `--version` command-line flag to the cnc program, allowing users to easily retrieve the current version number and the Git commit hash associated with the build. When invoked with `--version` or `-V`, the program will display this information, providing valuable insights into the exact version and build being used.

More,
  * Update configure.ac to dynamically set the version using `git describe`
  * Add COMMIT_HASH macro in Makefile.am and configure.ac
  * Modify cnc.c to handle the --version flag and display version information
  * Update help message to include the --version flag