### PR TITLE
db: postgres: Migrate `pg_dump` to `pg_dumpall` && `pg_restore` to `psql`

### DIFF
--- a/include/db/postgres.h
+++ b/include/db/postgres.h
@@ -4,13 +4,13 @@
 #include "db/db.h"
 
 /*
- * For the `pg_dump` and `pg_restore` to work we need to set the passwords as env variables,
+ * For the `pg_dump` and `psql` to work we need to set the passwords as env variables,
  * prefixed with `PGPASSWORD=`
  */
 #define PG_PASS_PREFIX 11
-#define PG_DUMP_COMMAND "pg_dump"
-#define PG_RESTORE_COMMAND "pg_restore"
-#define PG_DUMP_FILE "/backup.dump"
+#define PG_DUMP_COMMAND "pg_dumpall"
+#define PSQL_COMMAND "psql"
+#define PG_DUMP_FILE "/backup.sql"
 
 /*
  *  construct_pg

--- a/include/util.h
+++ b/include/util.h
@@ -44,7 +44,7 @@ int read_buffer_pipe(int *);
  *
  * Returns:
  *   0 Success
- *  -1 Failure of`pg_dump` or `pg_restore`
+ *  -1 Failure of`pg_dump` or `psql`
  *  -2 Failure of creation of fork() or pipe()
  *
  */

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -176,7 +176,7 @@ int exec_command(const char *pg_command_path, char *const args[], char *pg_pass,
  *
  * Returns:
  *   0 Success
- *  -1 Failure of`pg_dump` or `pg_restore`
+ *  -1 Failure of`pg_dump` or `psql`
  *  -2 Failure of creation of fork() or pipe()
  *
  */
@@ -194,15 +194,13 @@ int replicate(struct db_t *pg_db_t)
 
 	char *const dump_args[] = {
 		PG_DUMP_COMMAND,
-		"-h",
-		(char *const)pg_db_t->pg_conf->host.origin,
-		"-F",
-		"custom",
-		"-p",
-		(char *const)pg_db_t->pg_conf->port.origin,
 		"-U",
 		(char *const)pg_db_t->pg_conf->user.origin,
-		"-d",
+		"-h",
+		(char *const)pg_db_t->pg_conf->host.origin,
+		"-p",
+		(char *const)pg_db_t->pg_conf->port.origin,
+		"-l",
 		(char *const)pg_db_t->pg_conf->database.origin,
 		"-f",
 		backup_path,
@@ -212,17 +210,16 @@ int replicate(struct db_t *pg_db_t)
 	};
 
 	char *const restore_args[] = {
-		PG_RESTORE_COMMAND,
+		PSQL_COMMAND,
 		"-h",
 		(char *const)pg_db_t->pg_conf->host.target,
-		"-p",
-		(char *const)pg_db_t->pg_conf->port.target,
 		"-U",
 		(char *const)pg_db_t->pg_conf->user.target,
-		"-d",
+		"-p",
+		(char *const)pg_db_t->pg_conf->port.target,
 		(char *const)pg_db_t->pg_conf->database.target,
+		"-f",
 		backup_path,
-		"-v",
 		NULL
 	};
 
@@ -245,9 +242,9 @@ int replicate(struct db_t *pg_db_t)
 	if (ret != 0)
 		goto cleanup;
 
-	setup_command(&pg_command_path, &pg_pass, PG_RESTORE_COMMAND,
+	setup_command(&pg_command_path, &pg_pass, PSQL_COMMAND,
 		      pg_db_t->pg_conf->password.target, command_path,
-		      command_path_size, strlen(PG_RESTORE_COMMAND));
+		      command_path_size, strlen(PSQL_COMMAND));
 	ret = exec_command(pg_command_path, restore_args, pg_pass,
 			   prefixed_command_path);
 	if (ret != 0)


### PR DESCRIPTION
By using `pg_dumpall` instead of `pg_dump` we ensure that ALL resources of the database are being exported in the backup file, which is now an SQL script instead of `.dump` due to the nature of `pg_dumpall`. This means that previous issues are now resolved, i.e.
* Missing privileges
* Missing roles

We also migated from `pg_restore` to the standard `psql` command, running it in the format of,
	`psql -h <address> -U <user> -p <port> -f <SQL script>`

This, with the addition of `pg_dumpall` solves our major issue of being unable to run `pg_restore` on an already "_restored_" database.