### PR TITLE
docker: update Dockerfile to use Debian

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,3 +41,13 @@ jobs:
           ./autogen.sh
           ./configure
           make
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        uses: actions/checkout@v4
+
+      - name: Build Docker CNC
+        run: docker build -t cnc  .
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@ BUILT_SOURCES = $(RUST_LIBS)
 
 # Custom rule for building Rust libraries
 $(RUST_LIBS):
-	./scripts/build-rust-libs.sh
+	sh ./scripts/build-rust-libs.sh
 
 .PHONY: rust_libs
 


### PR DESCRIPTION
Image size: 192MB.

Use `sh <script>` in Makefile.am to fix issue with docker running the build-rust-libs.sh script.