### PR TITLE
fix dynamic-stack-buffer-overflow error

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -37,7 +37,6 @@ void *db_operation_thread(void *arg)
 int execute_db_operations(void)
 {
 	int ret = 0;
-	pthread_t threads[db_ops_counter];
 	init_db_func init_function;
 
 	available_dbs = (struct db_operations **)calloc(
@@ -61,6 +60,7 @@ int execute_db_operations(void)
 		}
 	}
 
+	pthread_t threads[db_ops_counter];
 	for (int i = 0; i < db_ops_counter; i++) {
 		int ret = pthread_create(&threads[i], NULL, db_operation_thread,
 					 (void *)available_dbs[i]);


### PR DESCRIPTION
Maybe we should consider adding `-pedantic` to our flags to potentially avoid future bugs like this.
However in this case the bug is not caught even with `-pedantic` due to the array being declared with a variable as its size
that happens to equal 0.